### PR TITLE
Edit and fix tickets

### DIFF
--- a/commands/ticket/new.js
+++ b/commands/ticket/new.js
@@ -8,13 +8,25 @@ module.exports.run = async(client, message, args) => {
     if (desac) return message.channel.send("Les tickets sont temporairement désactivés probablement dû à une surcharge. Veuillez nous en excuser.");
     if (message.guild.id !== config.serverId) return message.channel.send("Pas de ticket sur ce serveur");
 
+    let target = message.member;
+    if (args[0]) {
+        if (!message.member.permissions.has(PermissionFlagsBits.ManageMessages)) {
+            return message.reply("Vous n'avez pas la permission d'ouvrir un ticket pour quelqu'un d'autre");
+        }
+        let targetId = message.mentions.members?.first()?.id || (args[0].match(/^\d+$/) ? args[0] : null);
+        if (!targetId) return message.reply("Merci de mentionner un utilisateur ou de donner son ID (ex: `+ticket @Utilisateur` ou `+ticket 123456789012345678`)");
+        target = message.guild.members.cache.get(targetId) || await message.guild.members.fetch(targetId).catch(() => null);
+        if (!target) return message.reply("Cet utilisateur doit être présent sur le serveur pour lui ouvrir un ticket");
+    }
+    let openedForSomeoneElse = target.id !== message.author.id;
+
     message.guild.channels.create({
-        name: message.author.username,
+        name: target.user.username,
         type: ChannelType.GuildText,
-        topic: 'Ticket en attente de <@' + message.member.id+'>',
+        topic: 'Ticket en attente de <@' + target.id+'>',
         permissionOverwrites: [
             {
-                id: message.member.id,
+                id: target.id,
                 allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages, PermissionFlagsBits.EmbedLinks]
             },
             {
@@ -26,7 +38,7 @@ module.exports.run = async(client, message, args) => {
                 allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages, PermissionFlagsBits.EmbedLinks]
             }
         ],
-        parent: config.tickets.categoryWait, reason: 'Ticket de ' + message.author.tag
+        parent: config.tickets.categoryWait, reason: 'Ticket de ' + target.user.tag + (openedForSomeoneElse ? ' ouvert par ' + message.author.tag : '')
     }).then(async c => {
         if (!c || !c instanceof TextChannel) return message.reply("Désolé, il y'a une erreur quelque part");
         let reasons;
@@ -35,8 +47,12 @@ module.exports.run = async(client, message, args) => {
             if (!reasons) reasons = "**Veuillez réagir avec un émoji en dessous du message concernant votre demande**\n" + key + " " + value;
             else reasons = reasons.concat("\n" + key + " " + value);
         }
-        client.log(`Le ticket <#${c.id}> a été ouvert par ${message.author.tag}`, 'gen');
-        message.reply(`:white_check_mark: Votre Ticket a été créé, <#${c.id}>`); //Send msg in channel of opening
+        client.log(openedForSomeoneElse
+            ? `Le ticket <#${c.id}> a été ouvert pour ${target.user.tag} par ${message.author.tag}`
+            : `Le ticket <#${c.id}> a été ouvert par ${message.author.tag}`, 'gen');
+        message.reply(openedForSomeoneElse
+            ? `:white_check_mark: Le ticket a été créé pour ${target.user.tag}, <#${c.id}>`
+            : `:white_check_mark: Votre Ticket a été créé, <#${c.id}>`); //Send msg in channel of opening
 
         let options = [];
         for (const [key, value] of Object.entries(config.tickets.reasons)) { //Generate list of options
@@ -80,25 +96,25 @@ module.exports.run = async(client, message, args) => {
             await interaction.deferUpdate();
 
             let link = client.commands.get("link");
-            let username = await link.getFromDiscordId(client.mysqlingame, message.author.id);
+            let username = await link.getFromDiscordId(client.mysqlingame, target.id);
             let subject = config.tickets.reasons[interaction.values[0]];
 
             if (!username) {
-                await reason(client, newmsg, subject, message.author);
+                await reason(client, newmsg, subject, target.user);
             } else {
-                await pseudo(client, newmsg, username.player, subject, message.author);
+                await pseudo(client, newmsg, username.player, subject, target.user);
             }
         });
         collector.on('end', () => {
             if(!newmsg.channel) return;
             if(config.tickets.categoryWait !== newmsg.channel.parent.id) return collector.stop();
             if(collector.collected.size === 0){
-                console.log("Ticket of " + message.author.tag + " timeout on open");
+                console.log("Ticket of " + target.user.tag + " timeout on open");
                 newmsg.channel.send("Absence de plus de 5 minutes, fermeture du ticket dans 5 secondes." +
                     "\nVeuillez réessayer d'ouvrir un ticket et n'oubliez pas de définir le sujet du ticket.");
                 require("../../sleep.js")(5000);
                 newmsg.channel.delete();
-                message.author.send("Nous n'avons pas eu de réponse dans votre ticket depuis 5 minutes que vous n'avez pas finir d'ouvrir, le ticket a été fermé."+
+                target.user.send("Nous n'avons pas eu de réponse dans votre ticket depuis 5 minutes que vous n'avez pas finir d'ouvrir, le ticket a été fermé."+
                     "\nVeuillez réessayer d'ouvrir un ticket et n'oubliez pas de définir le sujet du ticket.");
             }
         });
@@ -252,8 +268,8 @@ async function description(message, reason, pseudo, description, author){
 
 module.exports.config = {
     name: "new",
-    description: "Ouvrir un ticket",
-    format: "new",
+    description: "Ouvrir un ticket (le staff peut l'ouvrir pour un joueur via +ticket {ID/@})",
+    format: "new [ID/@utilisateur]",
     canBeUseByBot: false,
     alias: ["ticket"],
     category: "Ticket"

--- a/commands/ticket/new.js
+++ b/commands/ticket/new.js
@@ -40,7 +40,7 @@ module.exports.run = async(client, message, args) => {
         ],
         parent: config.tickets.categoryWait, reason: 'Ticket de ' + target.user.tag + (openedForSomeoneElse ? ' ouvert par ' + message.author.tag : '')
     }).then(async c => {
-        if (!c || !c instanceof TextChannel) return message.reply("Désolé, il y'a une erreur quelque part");
+        if (!c || !(c instanceof TextChannel)) return message.reply("Désolé, il y'a une erreur quelque part");
         let reasons;
 
         for (const [key, value] of Object.entries(config.tickets.reasons)) {

--- a/commands/ticket/transcripts.js
+++ b/commands/ticket/transcripts.js
@@ -1,11 +1,22 @@
 const config = require('../../config.json');
 const {PermissionFlagsBits} = require("discord-api-types/v10");
+const {ActionRowBuilder, ButtonBuilder, ButtonStyle} = require("discord.js");
+
+const PAGE_SIZE = 10;
 
 module.exports.run = async(client, message, args) => {
-    let target = message.guild.members.cache.get(message.mentions.users.first());
+    // Fix: .mentions.users.first() renvoie un objet User, pas un ID -> il faut .mentions.members
+    let target = message.mentions.members?.first();
     if(!target) target = message.guild.members.cache.get(args[0]);
 
-    let callback = function(err, results) {sendResults(message, results, target?.id, args)};
+    let callback = function(err, results) {
+        if (err) {
+            console.error(err);
+            return message.reply("Une erreur est survenue lors de la récupération des transcripts.");
+        }
+        sendResults(message, results);
+    };
+
     if(!args[0]){
         client.mysqldiscord.execute('SELECT * FROM `transcripts` WHERE userid = ?', [message.author.id], callback);
     } else {
@@ -15,45 +26,85 @@ module.exports.run = async(client, message, args) => {
             } else if(args[0].match(/^\d+$/g)){
                 client.mysqldiscord.execute('SELECT * FROM `transcripts` WHERE userid = ?', [args[0]], callback);
             } else if(args[0] === 'name') {
-                    if (!args[1]) return message.reply('Il manque le nom de la personne ciblée');
-                    target = args[1];
-                    client.mysqldiscord.execute('SELECT * FROM `transcripts` WHERE username = ?', [target], callback);
+                if (!args[1]) return message.reply('Il manque le nom de la personne ciblée');
+                client.mysqldiscord.execute('SELECT * FROM `transcripts` WHERE username = ?', [args[1]], callback);
+            } else {
+                return message.reply("Argument invalide. Utilisez une mention, un ID, ou `name <pseudo>`");
             }
         } else return message.reply("Vous n'avez pas la permission");
     }
 };
-function sendResults(message, results, who, args, id = true)
+
+function buildPayload(message, results, page, totalPages, mentionId)
 {
-    if(!results[0]) return message.channel.send('Aucun résultat trouvé');
+    // Le mentionId vient toujours de la BDD (results[0].userid), jamais d'une variable
+    // qui pourrait être undefined -> fix du bug "Transcripts de <@undefined>"
+    let who;
+    if(message.author.id === mentionId) who = 'Vos transcripts';
+    else who = 'Transcripts de <@'+mentionId+'> ('+results[0].name+')';
 
-    if(message.author.id === who) who = 'Vos transcripts';
-    else if(id) who = 'Transcripts de <@'+who+'> ('+results[0].name+')';
-    else who = 'Transcripts de '+who+' (<@'+results[0].userid+'> '+results[0].name+')'
+    let start = page * PAGE_SIZE;
+    let pageResults = results.slice(start, start + PAGE_SIZE);
+    let content = pageResults.map(r => `${r.name} [${r.id}](https://transcripts.histeria.fr/${r.id})`).join('\n');
+    if(!content) content = 'Aucun transcript sur cette page';
 
-    let content = '';
-    results.forEach(result => {
-        content = content.concat(`${result.name} [${result.id}](https://transcripts.histeria.fr/${result.id}\)\n`)
-    });
     let d = new Date();
-    message.author.send({
+    let payload = {
         embeds: [{
-            title: `**__Transcripts__**`,
+            title: `**__Transcripts__**` + (totalPages > 1 ? ` (page ${page + 1}/${totalPages})` : ''),
             color: config.color,
             timestamp: d,
             footer: {
                 icon_url: config.imageURL,
-                text: "@Histeria "+d.getFullYear()
+                text: "@Histeria " + d.getFullYear()
             },
             fields: [
                 {
                     name: who,
-                    value: content.substring(0, 1024)
+                    value: content
                 }
             ],
         }]
-    }).then(() => message.reply('Je vous ai envoyé le résultat en DM'))
-        .catch(() => message.reply("Je n'arrive pas à vous envoyer de message, assurez vous d'autoriser les messages privés avec au moins un serveur en commun avec moi"));
+    };
+    if(totalPages > 1) payload.components = [buildRow(page, totalPages)];
+    return payload;
+}
 
+function buildRow(page, totalPages)
+{
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('transcripts_prev').setLabel('◀ Précédent').setStyle(ButtonStyle.Secondary).setDisabled(page === 0),
+        new ButtonBuilder().setCustomId('transcripts_next').setLabel('Suivant ▶').setStyle(ButtonStyle.Secondary).setDisabled(page >= totalPages - 1)
+    );
+}
+
+async function sendResults(message, results)
+{
+    if(!results[0]) return message.channel.send('Aucun résultat trouvé');
+
+    let mentionId = results[0].userid;
+    let totalPages = Math.ceil(results.length / PAGE_SIZE);
+    let page = 0;
+
+    message.author.send(buildPayload(message, results, page, totalPages, mentionId))
+        .then(async sentMsg => {
+            message.reply('Je vous ai envoyé le résultat en DM');
+            if(totalPages <= 1) return;
+
+            const filter = i => i.user.id === message.author.id && ['transcripts_prev', 'transcripts_next'].includes(i.customId);
+            const collector = sentMsg.createMessageComponentCollector({filter, time: 300000});
+
+            collector.on('collect', async interaction => {
+                if(interaction.customId === 'transcripts_prev' && page > 0) page--;
+                if(interaction.customId === 'transcripts_next' && page < totalPages - 1) page++;
+                await interaction.update(buildPayload(message, results, page, totalPages, mentionId));
+            });
+
+            collector.on('end', () => {
+                sentMsg.edit({components: []}).catch(() => {});
+            });
+        })
+        .catch(() => message.reply("Je n'arrive pas à vous envoyer de message, assurez vous d'autoriser les messages privés avec au moins un serveur en commun avec moi"));
 }
 
 module.exports.config = {

--- a/commands/ticket/transcripts.js
+++ b/commands/ticket/transcripts.js
@@ -41,7 +41,7 @@ function buildPayload(message, results, page, totalPages, mentionId)
     // qui pourrait être undefined -> fix du bug "Transcripts de <@undefined>"
     let who;
     if(message.author.id === mentionId) who = 'Vos transcripts';
-    else who = 'Transcripts de <@'+mentionId+'> ('+results[0].name+')';
+    else who = 'Transcripts de <@' + mentionId + '> (' + results[0].username + ')';
 
     let start = page * PAGE_SIZE;
     let pageResults = results.slice(start, start + PAGE_SIZE);
@@ -61,7 +61,7 @@ function buildPayload(message, results, page, totalPages, mentionId)
             fields: [
                 {
                     name: who,
-                    value: content
+                    value: content.length > 1024 ? content.slice(0, 1021) + '...' : content
                 }
             ],
         }]

--- a/commands/utility/idee.js
+++ b/commands/utility/idee.js
@@ -14,6 +14,10 @@ module.exports.run = async(client, message, args) => {
             for(const emote of [config.idees.emoteYes, config.idees.emoteNo]){
                 await msgidee.react(emote);
             }
+            await msgidee.startThread({
+                name: 'idée de ' + message.author.username,
+                autoArchiveDuration: 1440
+            }).catch(err => console.error("Impossible de créer le thread pour l'idée :", err));
         })
 };
 


### PR DESCRIPTION
**Change to the Ticket System**
- Add the `+ticket {ID/@}` command
  - Allow opening a ticket by mentioning a user (e.g. `+ticket @User` or `+ticket ID`)
  - The user must be present on the server
  - This would allow opening a ticket directly linked to a player, and thus automatically associating the transcript with that player instead of the staff `member
 
**Improvements to the Transcript System**
  - Implement a page system with a maximum of 10 transcripts per page (current issue: if a player has too many transcripts, the most recent ones become invisible once the character limit is reached)
  - Fix the user mention bug that hasn't worked for several years
  
This hasn't been tested, so it will need to be tested once applied