### PR TITLE
Take the rank roles back on unlink, and grant Boosteur while boosting

### DIFF
--- a/commands/ig/link.js
+++ b/commands/ig/link.js
@@ -1,4 +1,5 @@
 const config = require('../../config.json');
+const linkmanager = require('../../linkmanager');
 
 module.exports.run = async(client, message, args) => {
     //check if already linked
@@ -28,6 +29,11 @@ module.exports.run = async(client, message, args) => {
                     console.error(err);
                     return message.reply("Erreur");
                 }
+
+                //The link is what granted the rank roles and the booster rank, so the
+                //unlink is what takes them back
+                linkmanager.onUnlink(client, message.author.id)
+                    .catch(error => console.error("Nettoyage de la déliaison de " + message.author.id + " : " + error));
 
                 message.reply({
                     embeds: [{
@@ -77,7 +83,13 @@ module.exports.run = async(client, message, args) => {
 
                         client.mysqlingame.query("DELETE FROM `discord_verification` WHERE code = ?", [code]);
 
-                        client.commands.get("refreshrank").run(client, message, ["link"]);
+                        Promise.resolve()
+                            .then(() => client.commands.get("refreshrank").run(client, message, ["link"]))
+                            .catch(error => console.error("Refresh du rank après liaison : " + error));
+
+                        //A member who boosted before linking gets his booster rank now
+                        linkmanager.onLink(client, message.author.id)
+                            .catch(error => console.error("Grade booster après liaison de " + message.author.id + " : " + error));
 
                         message.reply({
                             embeds: [{

--- a/commands/ig/refreshrank.js
+++ b/commands/ig/refreshrank.js
@@ -1,4 +1,5 @@
 const config = require('../../config.json');
+const linkmanager = require('../../linkmanager');
 
 module.exports.run = async(client, message, args) => {
     let link = client.commands.get("link");
@@ -6,65 +7,112 @@ module.exports.run = async(client, message, args) => {
     if (!username) return; //error message already thrown
 
     client.mysqlingame.query("SELECT * FROM `ranks` WHERE player = ?", [username], async function (err, results) {
-        if (err) {
-            console.error(err);
-            message.reply("Erreur");
-        }
-
-        if (!results || !results[0]) return message.reply("Aucun joueur trouvé avec ce pseudo");
-        let result = results[0];
-
-        let rank = result.rank;
-        let permissions = result.perms.split(",");
-
-        if (permissions.includes("utility.prefix") && rank === "Omega") {
-            await message.member.roles.add(config.ranks.OmegaPerso, "Refresh rank");
-            message.reply("Vous avez reçu le grade Omega Perso");
-            return;
-        }
-
-        let discordRank = config.ranks[rank];
-        if (!discordRank && args[0] !== "link") return message.reply("Erreur: Rank non trouvé");
-
-        await message.member.roles.add(discordRank, "Refresh rank");
-        message.reply(`Vous avez reçu le grade ${rank}`);
-
-        client.mysqlingame.query("SELECT * FROM `temp_rank` WHERE player = ?", [username],
-            function (err, results) {
+        //mysql2 throws away the promise of this callback, so nothing may escape it
+        try {
             if (err) {
                 console.error(err);
-                message.reply("Erreur");
+                return message.reply("Erreur");
             }
 
-            if (!results || !results[0]) return;
+            if (!results || !results[0]) return message.reply("Aucun joueur trouvé avec ce pseudo");
             let result = results[0];
 
-            client.mysqldiscord.query("INSERT INTO `tempRank` (user, rank, timestamp) VALUES (?, ?, ?)",
-                [message.author.id, result.new, result.expire]);
-        });
+            let rank = result.rank;
+            let permissions = (result.perms || "").split(","); //perms is nullable in the game database
+
+            let discordRank = config.ranks[rank];
+            //Histerien, the staff ranks and Boosteur have no discord role: there is nothing
+            //to grant, and adding an undefined role id kills the process
+            if (!discordRank) {
+                if (args[0] === "link") return;
+                return message.reply("Erreur: Rank non trouvé");
+            }
+
+            let roles = [discordRank];
+            let label = rank;
+            if (permissions.includes("utility.prefix") && rank === "Omega") {
+                roles.push(config.ranks.OmegaPerso);
+                label = "Omega Perso";
+            }
+
+            for (const roleId of roles) {
+                if (!roleId) continue;
+                await message.member.roles.add(roleId, "Refresh rank");
+                //Registry of what the bot posted itself, read back when the account unlinks
+                await linkmanager.rememberRole(client, message.author.id, roleId, username);
+            }
+            message.reply(`Vous avez reçu le grade ${label}`);
+
+            client.mysqlingame.query("SELECT * FROM `temp_rank` WHERE player = ?", [username],
+                function (err, results) {
+                if (err) {
+                    console.error(err);
+                    return message.reply("Erreur");
+                }
+
+                if (!results || !results[0]) return;
+                let result = results[0];
+
+                //One row per user: a refresh replaces the deadline instead of stacking a
+                //second one next to it
+                client.mysqldiscord.query("DELETE FROM `tempRank` WHERE `user` = ?", [message.author.id],
+                    function (err) {
+                    if (err) return console.error(err);
+
+                    //`rank` is a reserved word since MySQL 8.0.2: unquoted, this insert is a
+                    //syntax error and the row is never written
+                    client.mysqldiscord.query("INSERT INTO `tempRank` (`user`, `rank`, `timestamp`) VALUES (?, ?, ?)",
+                        [message.author.id, result.new, result.expire],
+                        function (err) { if (err) console.error(err); });
+                });
+            });
+        } catch (error) {
+            console.error("Refresh du rank de " + username + " : " + error);
+        }
     })
 };
 
 //Check every hour if a player has a rank that should be removed
 module.exports.update = async(client) => {
-    client.mysqldiscord.query("SELECT * FROM `tempRank` WHERE timestamp < ?", [new Date().getTime() / 1000],
+    //update() is fired at boot right after login, before ready has filled the guild cache
+    let guild = client.guilds.cache.get(config.serverId);
+    if (!guild) return console.log("Expiration des ranks: serveur principal introuvable");
+
+    client.mysqldiscord.query("SELECT * FROM `tempRank` WHERE `timestamp` < ?", [Math.floor(Date.now() / 1000)],
         function (err, results) {
         if (err) {
             console.error(err);
             return;
         }
+        if (!results) return;
 
         //Loop over results and remove the rank
         results.forEach(result => {
             //Fetch member
-            client.guilds.cache.get(config.serverId).members.fetch(result.user).then(member => {
+            guild.members.fetch(result.user).then(async member => {
                 console.log("Remove rank for " + member.user.username + " (" + member.user.id + ")");
-                member.roles.remove(config.ranks[result.rank], "Fin de la période de rank");
-                if (result.rank === "Omega") member.roles.remove(config.ranks.OmegaPerso, "Fin de la période de rank");
-                client.mysqldiscord.query("DELETE FROM `tempRank` WHERE user = ?", [result.user]);
+
+                let roles = [config.ranks[result.rank]];
+                if (result.rank === "Omega") roles.push(config.ranks.OmegaPerso);
+
+                for (const roleId of roles) {
+                    if (!roleId) continue;
+                    await member.roles.remove(roleId, "Fin de la période de rank");
+                }
+
+                //Forget the row only once the roles are really gone, otherwise a transient
+                //failure orphans them for good
+                client.mysqldiscord.query("DELETE FROM `tempRank` WHERE `user` = ? AND `rank` = ?",
+                    [result.user, result.rank], function (err) { if (err) console.error(err); });
             }).catch(err => {
-                console.error("Impossible de fetch le membre " + result.user);
+                console.error("Impossible de retirer le rank de " + result.user);
                 console.error(err);
+
+                //Member gone from the server: nothing will ever act on this row again
+                if (err && err.code === 10007) {
+                    client.mysqldiscord.query("DELETE FROM `tempRank` WHERE `user` = ? AND `rank` = ?",
+                        [result.user, result.rank], function (err) { if (err) console.error(err); });
+                }
             });
         });
     });

--- a/config.json
+++ b/config.json
@@ -59,6 +59,16 @@
         }
     },
 
+    "booster": {
+        "enabled": true,
+        "rank": "Boosteur",
+        "days": 7,
+        "defaultRank": "Histerien",
+        "eligibleRanks": ["Histerien", "VIP", "Interplanetaire"],
+        "rconPorts": [19101, 19102, 19001, 19201, 19202],
+        "sweepMinutes": 60
+    },
+
     "ranks": {
         "Donateur": "802626827285430272",
         "OmegaPerso": "789981723248427038",

--- a/events/guildMemberUpdate.js
+++ b/events/guildMemberUpdate.js
@@ -1,7 +1,10 @@
 const config = require("../config.json");
 const mcutil = require('minecraft-server-util');
+const linkmanager = require("../linkmanager");
 
 module.exports = (client, oldMember, member) => {
+    boost(client, oldMember, member);
+
     if (member.pending || !oldMember.pending) return; //not accepted rules yet or already accepted
     if(member.guild.id === config.serverId) mcutil.statusBedrock('192.168.1.42', {port: config.port, enableSRV: true, timeout: 5000})
         .then((response) => {
@@ -51,5 +54,16 @@ module.exports = (client, oldMember, member) => {
 
     let role = member.guild.roles.cache.find(r => r.name === "Histerien");
     if(!role) return console.log("Il n'y a pas de role Histerien sur le serveur");
-    member.roles.add(role).catch();
+    member.roles.add(role).catch(error => console.error("Impossible de donner le role Histerien : " + error));
 };
+
+//Boosting sets premiumSince, unboosting clears it. This runs before the pending guard
+//above, which lets through the rules acceptance and nothing else.
+//An uncached oldMember carries no premiumSince, so a transition missed here is caught by
+//the reconciliation pass in linkmanager instead.
+function boost(client, oldMember, member) {
+    if (member.guild.id !== config.serverId) return;
+
+    if (!oldMember.premiumSince && member.premiumSince) linkmanager.onBoostStart(client, member);
+    else if (oldMember.premiumSince && !member.premiumSince) linkmanager.onBoostEnd(client, member);
+}

--- a/linkmanager.js
+++ b/linkmanager.js
@@ -164,6 +164,20 @@ async function linkedPlayer(client, userId) {
     return rows && rows[0] ? rows[0].player : null;
 }
 
+//discord_link has `player` for primary key and no index on `discord`, so every
+//WHERE discord = ? is a full table scan. A pass used to ask for one per registered member.
+//Reading the column once costs exactly one scan and answers all of them.
+async function loadLinks(client) {
+    let rows = await query(client.mysqlingame, "SELECT `discord`, `player` FROM `discord_link`");
+    let links = new Map();
+    if (rows) {
+        //Nothing forbids two rows for one discord id; keep the first, like linkedPlayer does,
+        //and treat an empty name as no link, like linkedPlayer's caller does
+        for (const row of rows) if (row.player && !links.has(row.discord)) links.set(row.discord, row.player);
+    }
+    return links;
+}
+
 //A player with no ranks row sits on the default rank, he is not an unknown player
 async function inGameRank(client, player) {
     let rows = await query(client.mysqlingame, "SELECT `rank` FROM `ranks` WHERE `player` = ?", [player]);
@@ -295,7 +309,7 @@ async function grantBooster(client, member, options = {}) {
     let conf = boosterConf();
     if (!boosterEnabled()) return "disabled";
 
-    let player = await linkedPlayer(client, member.id);
+    let player = options.player !== undefined ? options.player : await linkedPlayer(client, member.id);
     if (!player) {
         if (options.notify) {
             notifyOnce(member, "Merci pour ton boost !\nPour recevoir le grade " + conf.rank + " en jeu, il faut d'abord relier ton compte : tape `/link` en jeu, puis `"
@@ -361,11 +375,11 @@ async function grantBooster(client, member, options = {}) {
 
 //Sliding window. Re-running temprank with the same rank ADDS the remaining time instead of
 //replacing it, so a renewal has to be an absolute write.
-async function renewBooster(client, row) {
+async function renewBooster(client, row, known) {
     let conf = boosterConf();
     if (!boosterConfigured()) return "not-configured";
 
-    let player = await linkedPlayer(client, row.user);
+    let player = known !== undefined ? known : await linkedPlayer(client, row.user);
     if (!player) player = row.player;
 
     let expire = nowSeconds() + conf.days * DAY;
@@ -389,13 +403,16 @@ async function renewBooster(client, row) {
     return "renewed";
 }
 
-//Single entry point: renews what exists, grants what does not
+//Single entry point: renews what exists, grants what does not.
+//options.row and options.player let the reconciliation pass hand over what it already read,
+//instead of asking again once per member. Undefined means "not handed over", null means
+//"handed over, and there is none".
 async function ensureBooster(client, member, options = {}) {
     if (!boosterEnabled()) return "disabled";
 
-    let row = await boosterRow(client, member.id);
+    let row = options.row !== undefined ? options.row : await boosterRow(client, member.id);
     if (row) {
-        let outcome = await renewBooster(client, row);
+        let outcome = await renewBooster(client, row, options.player);
         if (outcome !== "regrant") return outcome;
     }
     return grantBooster(client, member, options);
@@ -488,19 +505,28 @@ async function sweep(client) {
         return console.error("Passe de reconciliation : impossible de recuperer les membres : " + err);
     }
 
-    await quiet(sweepRoles(client), "Passe de reconciliation des roles");
-    await quiet(sweepBoosters(client, members), "Passe de reconciliation des boosters");
+    //One read of the link table for the whole pass, instead of one per registered member.
+    //It is only a shortcut: both destructive branches confirm live before acting, so losing
+    //it costs speed, never correctness, and must not cancel the pass.
+    let links = await quiet(loadLinks(client), "Passe de reconciliation : lecture des liaisons");
+    if (!links) links = new Map();
+
+    await quiet(sweepRoles(client, links), "Passe de reconciliation des roles");
+    await quiet(sweepBoosters(client, members, links), "Passe de reconciliation des boosters");
 }
 
 //Only touches roles the bot recorded posting itself, so a rank offered by hand is safe
-async function sweepRoles(client) {
+async function sweepRoles(client, links) {
     let rows = await query(client.mysqldiscord, "SELECT DISTINCT `user` FROM `rankRoleGrant`");
     if (!rows) return;
 
     for (const row of rows) {
         try {
-            let player = await linkedPlayer(client, row.user);
-            if (player) continue;
+            if (links.has(row.user)) continue;
+            //The snapshot is a few seconds old and what follows takes roles away, so the
+            //rare member it points at is confirmed live first. Costs one query per member
+            //actually concerned, not one per member in the register.
+            if (await linkedPlayer(client, row.user)) continue;
 
             let granted = await grantedRoles(client, row.user);
             let roles = await removeRoles(client, row.user, granted, "Compte de jeu delie");
@@ -519,28 +545,31 @@ async function sweepRoles(client) {
 
 //Sequential on purpose: MiniCore reads temp_rank before writing it, outside its own
 //callback, so two concurrent rank commands on the same player race each other.
-async function sweepBoosters(client, members) {
+async function sweepBoosters(client, members, links) {
     let rows = await query(client.mysqldiscord, "SELECT * FROM `boosterRank`");
-    if (rows) {
-        for (const row of rows) {
-            try {
-                let member = members.get(row.user);
-                if (!member) {
-                    await revokeBooster(client, row.user, "Membre parti du serveur");
-                    continue;
-                }
-                if (!member.premiumSince) {
-                    await revokeBooster(client, row.user, "Fin du boost");
-                    continue;
-                }
-                //Still boosting is not enough. The account may have unlinked in game, which
-                //the bot is never told about, and the sibling pass above has already taken
-                //his discord roles back for exactly that reason.
-                let player = await linkedPlayer(client, row.user);
-                if (!player) await revokeBooster(client, row.user, "Compte de jeu delie");
-            } catch (err) {
-                console.error("Retrait du grade booster de " + row.user + " : " + err);
-            }
+
+    //The whole table, so an absent key means "no grant", not "not looked up yet"
+    let granted = new Map();
+    if (rows) for (const row of rows) granted.set(row.user, row);
+
+    for (const row of rows || []) {
+        try {
+            let member = members.get(row.user);
+            let reason = null;
+
+            if (!member) reason = "Membre parti du serveur";
+            else if (!member.premiumSince) reason = "Fin du boost";
+            //Still boosting is not enough. The account may have unlinked in game, which the
+            //bot is never told about, and the sibling pass above has already taken his
+            //discord roles back for exactly that reason.
+            //Same as above: confirmed live, because this one takes a rank away
+            else if (!links.has(row.user) && !await linkedPlayer(client, row.user)) reason = "Compte de jeu delie";
+
+            if (!reason) continue;
+            await revokeBooster(client, row.user, reason);
+            granted.delete(row.user);
+        } catch (err) {
+            console.error("Retrait du grade booster de " + row.user + " : " + err);
         }
     }
 
@@ -549,7 +578,11 @@ async function sweepBoosters(client, members) {
     for (const member of members.values()) {
         if (!member.premiumSince) continue;
         try {
-            await ensureBooster(client, member, {notify: false});
+            await ensureBooster(client, member, {
+                notify: false,
+                row: granted.has(member.id) ? granted.get(member.id) : null,
+                player: links.has(member.id) ? links.get(member.id) : null
+            });
         } catch (err) {
             console.error("Grade booster pour " + member.id + " : " + err);
         }

--- a/linkmanager.js
+++ b/linkmanager.js
@@ -1,0 +1,563 @@
+const config = require("./config.json");
+
+const DAY = 86400;
+const RCON_TIMEOUT = 8000;
+const APPLY_TRIES = 6;
+const APPLY_DELAY = 700;
+
+let sweepTimer = null;
+
+/* ------------------------------------------------------------------ *
+ * Helpers
+ * ------------------------------------------------------------------ */
+
+function query(connection, sql, params = []) {
+    return new Promise((resolve, reject) => {
+        connection.query(sql, params, (err, results) => {
+            if (err) reject(err);
+            else resolve(results);
+        });
+    });
+}
+
+function nowSeconds() {
+    return Math.floor(Date.now() / 1000);
+}
+
+function wait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+//Never let a rejected promise escape into a mysql2 callback: that kills the process
+function quiet(promise, context) {
+    return promise.catch(err => {
+        console.error(context + " : " + err);
+        return null;
+    });
+}
+
+//client.log resolves a channel and sends: its rejection would float free otherwise
+function log(client, text) {
+    Promise.resolve()
+        .then(() => client.log(text, "staff"))
+        .catch(err => console.error("Log staff impossible : " + err));
+}
+
+function boosterConf() {
+    return config.booster || {};
+}
+
+//Everything the booster feature needs before it may touch anything. Fails closed.
+function boosterConfigured() {
+    let conf = boosterConf();
+    return typeof conf.rank === "string" && conf.rank !== ""
+        && Array.isArray(conf.rconPorts) && conf.rconPorts.length > 0
+        && Number.isInteger(conf.days) && conf.days > 0;
+}
+
+function boosterEnabled() {
+    return boosterConf().enabled === true && boosterConfigured();
+}
+
+function defaultRank() {
+    return boosterConf().defaultRank || "Histerien";
+}
+
+//The five rank roles refreshrank knows how to grant
+function rankRoleIds() {
+    return Object.values(config.ranks || {}).filter(id => typeof id === "string" && id !== "");
+}
+
+/* ------------------------------------------------------------------ *
+ * RCON
+ * ------------------------------------------------------------------ */
+
+function rconFunc(client) {
+    let cmd = client.commands.get("rcon");
+    if (!cmd || !cmd.config || typeof cmd.config.rconfunc !== "function") return null;
+    return cmd.config.rconfunc;
+}
+
+//rconfunc only settles on the 'output' event, so it hangs forever when a server accepts
+//the connection and never answers. Every call has to carry its own deadline.
+function withTimeout(promise, ms, label) {
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        let timer = setTimeout(() => {
+            settled = true;
+            reject(new Error("Pas de reponse RCON de " + label));
+        }, ms);
+
+        promise.then(value => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve(value);
+        }, err => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            reject(err);
+        });
+    });
+}
+
+//Runs the command on the first server that answers. The game database is shared, so
+//running a rank command twice would be a duplicate write, never a fallback.
+async function rconFirst(client, command) {
+    let run = rconFunc(client);
+    if (!run) return null;
+
+    for (const port of boosterConf().rconPorts) {
+        try {
+            let output = await withTimeout(run(port, command, null, port, false), RCON_TIMEOUT, port);
+            return {port: port, output: output == null ? "" : String(output)};
+        } catch (err) {
+            console.error("RCON " + port + " injoignable pour \"" + command + "\" : " + err);
+        }
+    }
+    return null;
+}
+
+//Best effort refresh of the players already connected on the other servers. setrank writes
+//the same value everywhere, so a failure here costs nothing but a relog.
+async function rconBroadcast(client, command, skipPort) {
+    let run = rconFunc(client);
+    if (!run) return;
+
+    for (const port of boosterConf().rconPorts) {
+        if (port === skipPort) continue;
+        await withTimeout(run(port, command, null, port, false), RCON_TIMEOUT, port).catch(() => null);
+    }
+}
+
+/* ------------------------------------------------------------------ *
+ * Tables
+ * ------------------------------------------------------------------ */
+
+//The discord schema has no migration anywhere, its tables were created by hand.
+//These two create themselves so a deploy is enough.
+async function ensureTables(client) {
+    await query(client.mysqldiscord,
+        "CREATE TABLE IF NOT EXISTS `rankRoleGrant` (" +
+        "`user` VARCHAR(20) NOT NULL, " +
+        "`role` VARCHAR(20) NOT NULL, " +
+        "`player` VARCHAR(20) NOT NULL, " +
+        "`granted_at` INT NOT NULL, " +
+        "PRIMARY KEY (`user`, `role`))");
+
+    await query(client.mysqldiscord,
+        "CREATE TABLE IF NOT EXISTS `boosterRank` (" +
+        "`user` VARCHAR(20) NOT NULL PRIMARY KEY, " +
+        "`player` VARCHAR(20) NOT NULL, " +
+        "`old_rank` VARCHAR(32) NOT NULL, " +
+        "`granted_at` INT NOT NULL, " +
+        "`expire` INT NOT NULL)");
+}
+
+/* ------------------------------------------------------------------ *
+ * Reading the link
+ * ------------------------------------------------------------------ */
+
+async function linkedPlayer(client, userId) {
+    let rows = await query(client.mysqlingame, "SELECT `player` FROM `discord_link` WHERE `discord` = ?", [userId]);
+    return rows && rows[0] ? rows[0].player : null;
+}
+
+//A player with no ranks row sits on the default rank, he is not an unknown player
+async function inGameRank(client, player) {
+    let rows = await query(client.mysqlingame, "SELECT `rank` FROM `ranks` WHERE `player` = ?", [player]);
+    let rank = rows && rows[0] ? rows[0].rank : null;
+    return rank ? rank : defaultRank();
+}
+
+//temp_rank.player is PRIMARY KEY UNIQUE: one temporary rank per player, never two
+async function tempRankRow(client, player) {
+    let rows = await query(client.mysqlingame, "SELECT * FROM `temp_rank` WHERE `player` = ?", [player]);
+    return rows && rows[0] ? rows[0] : null;
+}
+
+async function mainMember(client, userId) {
+    let guild = client.guilds.cache.get(config.serverId);
+    if (!guild) return null;
+    return guild.members.fetch(userId).catch(() => null);
+}
+
+function notify(member, text) {
+    if (!member) return Promise.resolve(null);
+    return member.send(text).catch(() => null);
+}
+
+//An uncached oldMember carries no premiumSince, so guildMemberUpdate can report a boost
+//that already existed. Granting is idempotent, but the refusal messages would be sent
+//again every time, so each member only hears about a refusal once.
+const notified = new Set();
+
+function notifyOnce(member, text) {
+    if (!member || notified.has(member.id)) return;
+    notified.add(member.id);
+    notify(member, text);
+}
+
+/* ------------------------------------------------------------------ *
+ * Register of the rank roles the bot posted itself
+ * ------------------------------------------------------------------ */
+
+async function rememberRole(client, userId, roleId, player) {
+    if (!roleId) return;
+    await quiet(query(client.mysqldiscord,
+        "INSERT INTO `rankRoleGrant` (`user`, `role`, `player`, `granted_at`) VALUES (?, ?, ?, ?) " +
+        "ON DUPLICATE KEY UPDATE `player` = VALUES(`player`), `granted_at` = VALUES(`granted_at`)",
+        [userId, roleId, player, nowSeconds()]), "Enregistrement du role " + roleId + " pour " + userId);
+}
+
+async function grantedRoles(client, userId) {
+    let rows = await query(client.mysqldiscord, "SELECT `role` FROM `rankRoleGrant` WHERE `user` = ?", [userId]);
+    return rows ? rows.map(row => row.role) : [];
+}
+
+async function forgetRoles(client, userId) {
+    await query(client.mysqldiscord, "DELETE FROM `rankRoleGrant` WHERE `user` = ?", [userId]);
+}
+
+//Always resolves the member on the main server: +link is usable from the staff server and
+//from any other guild the bot sits in, where message.member would be the wrong member.
+async function removeRoles(client, userId, roleIds, reason) {
+    let member = await mainMember(client, userId);
+    if (!member) return [];
+
+    let removed = [];
+    for (const roleId of roleIds) {
+        if (!roleId || !member.roles.cache.has(roleId)) continue;
+        try {
+            await member.roles.remove(roleId, reason);
+            removed.push(roleId);
+        } catch (err) {
+            console.error("Retrait du role " + roleId + " impossible pour " + userId + " : " + err);
+            log(client, "Impossible de retirer le role " + roleId + " a <@" + userId + "> : " + err);
+        }
+    }
+    return removed;
+}
+
+/* ------------------------------------------------------------------ *
+ * Unlinking
+ * ------------------------------------------------------------------ */
+
+//Called from +link remove, where the account really was linked a second ago. The five
+//config.ranks roles all come from the link, so all five go.
+async function onUnlink(client, userId) {
+    let removed = await removeRoles(client, userId, rankRoleIds(), "Compte de jeu delie");
+    await quiet(forgetRoles(client, userId), "Nettoyage du registre de roles de " + userId);
+    await quiet(query(client.mysqldiscord, "DELETE FROM `tempRank` WHERE `user` = ?", [userId]),
+        "Nettoyage de tempRank pour " + userId);
+
+    let booster = await quiet(revokeBooster(client, userId, "Compte de jeu delie"), "Retrait du grade booster de " + userId);
+
+    if (removed.length) {
+        log(client, "<@" + userId + "> s'est delie, " + removed.length + " role(s) de grade retire(s)");
+    }
+    return {roles: removed, booster: booster};
+}
+
+/* ------------------------------------------------------------------ *
+ * Booster rank in game
+ * ------------------------------------------------------------------ */
+
+async function boosterRow(client, userId) {
+    let rows = await query(client.mysqldiscord, "SELECT * FROM `boosterRank` WHERE `user` = ?", [userId]);
+    return rows && rows[0] ? rows[0] : null;
+}
+
+//MiniCore writes temp_rank through libasynql, so the row lands a moment after the command
+async function waitForTempRank(client, player, rank) {
+    for (let i = 0; i < APPLY_TRIES; i++) {
+        await wait(APPLY_DELAY);
+        let row = await tempRankRow(client, player);
+        if (row && row.new === rank) return row;
+    }
+    return null;
+}
+
+//Grants the rank, once. Never called when a boosterRank row already exists.
+async function grantBooster(client, member, options = {}) {
+    let conf = boosterConf();
+    if (!boosterEnabled()) return "disabled";
+
+    let player = await linkedPlayer(client, member.id);
+    if (!player) {
+        if (options.notify) {
+            notifyOnce(member, "Merci pour ton boost !\nPour recevoir le grade " + conf.rank + " en jeu, il faut d'abord relier ton compte : tape `/link` en jeu, puis `"
+                + config.prefix + "link <code>` sur le Discord. Le grade te sera donne automatiquement.");
+        }
+        return "unlinked";
+    }
+
+    //One temporary rank per player, and giving a second one destroys the first: a shop
+    //purchase in flight must never be overwritten by a boost.
+    let temp = await tempRankRow(client, player);
+    if (temp) {
+        if (options.notify) {
+            notifyOnce(member, "Merci pour ton boost !\nTu as deja un grade temporaire en cours (" + temp.new + "), il n'a pas ete remplace. Le grade "
+                + conf.rank + " te sera donne automatiquement des qu'il sera termine.");
+        }
+        return "temp-busy";
+    }
+
+    //There is no rank ordering anywhere in the game, so the list of ranks that may be
+    //replaced is written in config. An unknown rank is not in the list, so it is kept.
+    let current = await inGameRank(client, player);
+    let eligible = Array.isArray(conf.eligibleRanks) ? conf.eligibleRanks : [];
+    if (!eligible.includes(current)) {
+        if (options.notify) {
+            notifyOnce(member, "Merci pour ton boost !\nTon grade actuel en jeu (" + current + ") est meilleur que " + conf.rank
+                + ", il n'a donc pas ete remplace. Tu gardes tout ce que tu avais.");
+        }
+        return "better-rank";
+    }
+
+    let result = await rconFirst(client, "temprank " + player + " " + conf.rank + " " + conf.days + "d");
+    if (!result) {
+        log(client, "Grade " + conf.rank + " impossible a donner a " + player + " (<@" + member.id + ">) : aucun serveur RCON n'a repondu");
+        return "rcon-down";
+    }
+
+    //ranks.yml is read from the server, not from this repo, so the rank may simply not
+    //exist there. The written row is the only proof the grant landed.
+    let row = await waitForTempRank(client, player, conf.rank);
+    if (!row) {
+        log(client, "Grade " + conf.rank + " demande pour " + player + " (<@" + member.id + ">) mais aucune ligne temp_rank n'est apparue. Reponse du serveur : "
+            + (result.output || "aucune"));
+        return "not-applied";
+    }
+
+    await query(client.mysqldiscord,
+        "INSERT INTO `boosterRank` (`user`, `player`, `old_rank`, `granted_at`, `expire`) VALUES (?, ?, ?, ?, ?) " +
+        "ON DUPLICATE KEY UPDATE `player` = VALUES(`player`), `old_rank` = VALUES(`old_rank`), `expire` = VALUES(`expire`)",
+        [member.id, player, row.old || defaultRank(), nowSeconds(), row.expire]);
+
+    await rconBroadcast(client, "setrank " + player + " " + conf.rank, result.port);
+
+    //He may hear about a refusal again if he loses the rank and boosts again later
+    notified.delete(member.id);
+    if (options.notify) {
+        notify(member, "Merci pour ton boost !\nTu as recu le grade " + conf.rank + " en jeu sur " + player
+            + ". Il te reste tant que tu boostes le serveur, et tu retrouveras ton grade precedent (" + (row.old || defaultRank()) + ") en le retirant.");
+    }
+    log(client, "Grade " + conf.rank + " donne a " + player + " (<@" + member.id + ">) pour un boost");
+    return "granted";
+}
+
+//Sliding window. Re-running temprank with the same rank ADDS the remaining time instead of
+//replacing it, so a renewal has to be an absolute write.
+async function renewBooster(client, row) {
+    let conf = boosterConf();
+    if (!boosterConfigured()) return "not-configured";
+
+    let player = await linkedPlayer(client, row.user);
+    if (!player) player = row.player;
+
+    let expire = nowSeconds() + conf.days * DAY;
+    let result = await query(client.mysqlingame,
+        "UPDATE `temp_rank` SET `expire` = ? WHERE `player` = ? AND `new` = ?", [expire, player, conf.rank]);
+
+    //Row gone (already expired and consumed at a login, wiped by datam) or replaced by
+    //another temporary rank: our bookkeeping is stale, drop it and let the caller retry.
+    if (!result || result.affectedRows === 0) {
+        await query(client.mysqldiscord, "DELETE FROM `boosterRank` WHERE `user` = ?", [row.user]);
+        return "regrant";
+    }
+
+    await query(client.mysqldiscord, "UPDATE `boosterRank` SET `player` = ?, `expire` = ? WHERE `user` = ?",
+        [player, expire, row.user]);
+    return "renewed";
+}
+
+//Single entry point: renews what exists, grants what does not
+async function ensureBooster(client, member, options = {}) {
+    if (!boosterEnabled()) return "disabled";
+
+    let row = await boosterRow(client, member.id);
+    if (row) {
+        let outcome = await renewBooster(client, row);
+        if (outcome !== "regrant") return outcome;
+    }
+    return grantBooster(client, member, options);
+}
+
+//Reads what the bot posted itself, never the rank the player is wearing
+async function revokeBooster(client, userId, reason) {
+    let conf = boosterConf();
+    if (!boosterConfigured()) return "not-configured";
+
+    let row = await boosterRow(client, userId);
+    if (!row) return "nothing";
+
+    let player = await linkedPlayer(client, userId);
+    if (!player) player = row.player;
+
+    let current = await inGameRank(client, player);
+    let back = row.old_rank || defaultRank();
+    let outcome;
+
+    if (current === conf.rank) {
+        //Safety net first: an expired row makes MiniCore itself restore the rank at the next
+        //login, whatever happens to the RCON call below.
+        await query(client.mysqlingame, "UPDATE `temp_rank` SET `expire` = ? WHERE `player` = ? AND `new` = ?",
+            [nowSeconds() - 1, player, conf.rank]);
+
+        let result = await rconFirst(client, "setrank " + player + " " + back);
+        if (result) {
+            await query(client.mysqlingame, "DELETE FROM `temp_rank` WHERE `player` = ? AND `new` = ?", [player, conf.rank]);
+            await rconBroadcast(client, "setrank " + player + " " + back, result.port);
+            outcome = "restored";
+        } else {
+            outcome = "deferred";
+        }
+    } else {
+        //Someone else moved his rank in the meantime. Leave it alone, but drop our row so
+        //MiniCore does not undo their change at the next login.
+        await query(client.mysqlingame, "DELETE FROM `temp_rank` WHERE `player` = ? AND `new` = ?", [player, conf.rank]);
+        outcome = "superseded";
+    }
+
+    await query(client.mysqldiscord, "DELETE FROM `boosterRank` WHERE `user` = ?", [userId]);
+    notified.delete(userId);
+    log(client, "Grade " + conf.rank + " retire a " + player + " (<@" + userId + ">) : " + reason + " [" + outcome + "]");
+    return outcome;
+}
+
+/* ------------------------------------------------------------------ *
+ * Events
+ * ------------------------------------------------------------------ */
+
+async function onBoostStart(client, member) {
+    if (!boosterEnabled()) return;
+    if (member.guild.id !== config.serverId) return;
+    await quiet(ensureBooster(client, member, {notify: true}), "Grade booster pour " + member.id);
+}
+
+async function onBoostEnd(client, member) {
+    if (!boosterConfigured()) return;
+    if (member.guild.id !== config.serverId) return;
+    await quiet(revokeBooster(client, member.id, "Fin du boost"), "Retrait du grade booster de " + member.id);
+}
+
+//Called right after a successful +link, so a booster who linked late gets his rank
+async function onLink(client, userId) {
+    if (!boosterEnabled()) return;
+    let member = await mainMember(client, userId);
+    if (!member || !member.premiumSince) return;
+    await quiet(ensureBooster(client, member, {notify: true}), "Grade booster pour " + userId);
+}
+
+/* ------------------------------------------------------------------ *
+ * Reconciliation
+ * ------------------------------------------------------------------ */
+
+//Catches everything the events cannot see: a boost started or dropped while the bot was
+//down, a member who left, and the two unlink paths the bot is never told about
+//(/link remove in game, and the staff datam command).
+async function sweep(client) {
+    let guild = client.guilds.cache.get(config.serverId);
+    if (!guild) return console.log("Passe de reconciliation : serveur principal introuvable");
+
+    let members;
+    try {
+        members = await guild.members.fetch();
+    } catch (err) {
+        return console.error("Passe de reconciliation : impossible de recuperer les membres : " + err);
+    }
+
+    await quiet(sweepRoles(client), "Passe de reconciliation des roles");
+    await quiet(sweepBoosters(client, members), "Passe de reconciliation des boosters");
+}
+
+//Only touches roles the bot recorded posting itself, so a rank offered by hand is safe
+async function sweepRoles(client) {
+    let rows = await query(client.mysqldiscord, "SELECT DISTINCT `user` FROM `rankRoleGrant`");
+    if (!rows) return;
+
+    for (const row of rows) {
+        try {
+            let player = await linkedPlayer(client, row.user);
+            if (player) continue;
+
+            let roles = await grantedRoles(client, row.user);
+            let removed = await removeRoles(client, row.user, roles, "Compte de jeu delie");
+            await forgetRoles(client, row.user);
+            await quiet(query(client.mysqldiscord, "DELETE FROM `tempRank` WHERE `user` = ?", [row.user]),
+                "Nettoyage de tempRank pour " + row.user);
+
+            if (removed.length) {
+                log(client, "<@" + row.user + "> n'est plus lie a un compte de jeu, " + removed.length + " role(s) de grade retire(s)");
+            }
+        } catch (err) {
+            console.error("Reconciliation des roles de " + row.user + " : " + err);
+        }
+    }
+}
+
+//Sequential on purpose: MiniCore reads temp_rank before writing it, outside its own
+//callback, so two concurrent rank commands on the same player race each other.
+async function sweepBoosters(client, members) {
+    let rows = await query(client.mysqldiscord, "SELECT * FROM `boosterRank`");
+    if (rows) {
+        for (const row of rows) {
+            try {
+                let member = members.get(row.user);
+                if (member && member.premiumSince) continue;
+                await revokeBooster(client, row.user, member ? "Fin du boost" : "Membre parti du serveur");
+            } catch (err) {
+                console.error("Retrait du grade booster de " + row.user + " : " + err);
+            }
+        }
+    }
+
+    if (!boosterEnabled()) return;
+
+    for (const member of members.values()) {
+        if (!member.premiumSince) continue;
+        try {
+            await ensureBooster(client, member, {notify: false});
+        } catch (err) {
+            console.error("Grade booster pour " + member.id + " : " + err);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ *
+ * Startup
+ * ------------------------------------------------------------------ */
+
+//ready can fire again after a reconnection, so the interval is installed only once
+async function start(client) {
+    if (sweepTimer) return;
+
+    let ready = await quiet(ensureTables(client), "Creation des tables du module de liaison");
+    if (ready === null) return console.error("Module de liaison desactive : les tables n'ont pas pu etre creees");
+
+    let minutes = Number.isInteger(boosterConf().sweepMinutes) && boosterConf().sweepMinutes > 0
+        ? boosterConf().sweepMinutes : 60;
+
+    sweepTimer = setInterval(() => {
+        quiet(sweep(client), "Passe de reconciliation");
+    }, minutes * 60 * 1000);
+
+    await quiet(sweep(client), "Passe de reconciliation");
+}
+
+module.exports = {
+    start: start,
+    sweep: sweep,
+    onUnlink: onUnlink,
+    onLink: onLink,
+    onBoostStart: onBoostStart,
+    onBoostEnd: onBoostEnd,
+    ensureBooster: ensureBooster,
+    revokeBooster: revokeBooster,
+    rememberRole: rememberRole,
+    rankRoleIds: rankRoleIds,
+    mainMember: mainMember,
+    query: query
+};

--- a/linkmanager.js
+++ b/linkmanager.js
@@ -216,28 +216,39 @@ async function grantedRoles(client, userId) {
     return rows ? rows.map(row => row.role) : [];
 }
 
-async function forgetRoles(client, userId) {
-    await query(client.mysqldiscord, "DELETE FROM `rankRoleGrant` WHERE `user` = ?", [userId]);
+//`keep` holds the roles whose removal just failed: their register rows stay so the next
+//pass tries again, instead of forgetting a role that is still on the member.
+async function forgetRoles(client, userId, keep = []) {
+    if (!keep.length) {
+        await query(client.mysqldiscord, "DELETE FROM `rankRoleGrant` WHERE `user` = ?", [userId]);
+        return;
+    }
+    let holes = keep.map(() => "?").join(", ");
+    await query(client.mysqldiscord,
+        "DELETE FROM `rankRoleGrant` WHERE `user` = ? AND `role` NOT IN (" + holes + ")", [userId].concat(keep));
 }
 
 //Always resolves the member on the main server: +link is usable from the staff server and
 //from any other guild the bot sits in, where message.member would be the wrong member.
+//Reports what failed, because forgetting a role that is still worn strands it for good.
 async function removeRoles(client, userId, roleIds, reason) {
     let member = await mainMember(client, userId);
-    if (!member) return [];
+    if (!member) return {removed: [], failed: []};
 
     let removed = [];
+    let failed = [];
     for (const roleId of roleIds) {
         if (!roleId || !member.roles.cache.has(roleId)) continue;
         try {
             await member.roles.remove(roleId, reason);
             removed.push(roleId);
         } catch (err) {
+            failed.push(roleId);
             console.error("Retrait du role " + roleId + " impossible pour " + userId + " : " + err);
             log(client, "Impossible de retirer le role " + roleId + " a <@" + userId + "> : " + err);
         }
     }
-    return removed;
+    return {removed: removed, failed: failed};
 }
 
 /* ------------------------------------------------------------------ *
@@ -247,17 +258,17 @@ async function removeRoles(client, userId, roleIds, reason) {
 //Called from +link remove, where the account really was linked a second ago. The five
 //config.ranks roles all come from the link, so all five go.
 async function onUnlink(client, userId) {
-    let removed = await removeRoles(client, userId, rankRoleIds(), "Compte de jeu delie");
-    await quiet(forgetRoles(client, userId), "Nettoyage du registre de roles de " + userId);
+    let roles = await removeRoles(client, userId, rankRoleIds(), "Compte de jeu delie");
+    await quiet(forgetRoles(client, userId, roles.failed), "Nettoyage du registre de roles de " + userId);
     await quiet(query(client.mysqldiscord, "DELETE FROM `tempRank` WHERE `user` = ?", [userId]),
         "Nettoyage de tempRank pour " + userId);
 
     let booster = await quiet(revokeBooster(client, userId, "Compte de jeu delie"), "Retrait du grade booster de " + userId);
 
-    if (removed.length) {
-        log(client, "<@" + userId + "> s'est delie, " + removed.length + " role(s) de grade retire(s)");
+    if (roles.removed.length) {
+        log(client, "<@" + userId + "> s'est delie, " + roles.removed.length + " role(s) de grade retire(s)");
     }
-    return {roles: removed, booster: booster};
+    return {roles: roles.removed, failed: roles.failed, booster: booster};
 }
 
 /* ------------------------------------------------------------------ *
@@ -364,6 +375,11 @@ async function renewBooster(client, row) {
     //Row gone (already expired and consumed at a login, wiped by datam) or replaced by
     //another temporary rank: our bookkeeping is stale, drop it and let the caller retry.
     if (!result || result.affectedRows === 0) {
+        //The discord account may have moved to another minecraft name. Our row is then still
+        //standing on the old one, and MiniCore reads it as an order to demote that account at
+        //its next login, which would wipe anything bought since. Undo it before letting go.
+        if (player !== row.player) await releaseTempRank(client, row.player, row.old_rank || defaultRank());
+
         await query(client.mysqldiscord, "DELETE FROM `boosterRank` WHERE `user` = ?", [row.user]);
         return "regrant";
     }
@@ -385,6 +401,32 @@ async function ensureBooster(client, member, options = {}) {
     return grantBooster(client, member, options);
 }
 
+//Undoes our own temporary rank on one minecraft account. Shared by the revoke path and by
+//the renewal that discovers its account changed.
+async function releaseTempRank(client, player, back) {
+    let conf = boosterConf();
+    let current = await inGameRank(client, player);
+
+    if (current !== conf.rank) {
+        //Someone else moved his rank in the meantime. Leave it alone, but drop our row so
+        //MiniCore does not undo their change at the next login.
+        await query(client.mysqlingame, "DELETE FROM `temp_rank` WHERE `player` = ? AND `new` = ?", [player, conf.rank]);
+        return "superseded";
+    }
+
+    //Safety net first: an expired row makes MiniCore itself restore the rank at the next
+    //login, whatever happens to the RCON call below.
+    await query(client.mysqlingame, "UPDATE `temp_rank` SET `expire` = ? WHERE `player` = ? AND `new` = ?",
+        [nowSeconds() - 1, player, conf.rank]);
+
+    let result = await rconFirst(client, "setrank " + player + " " + back);
+    if (!result) return "deferred";
+
+    await query(client.mysqlingame, "DELETE FROM `temp_rank` WHERE `player` = ? AND `new` = ?", [player, conf.rank]);
+    await rconBroadcast(client, "setrank " + player + " " + back, result.port);
+    return "restored";
+}
+
 //Reads what the bot posted itself, never the rank the player is wearing
 async function revokeBooster(client, userId, reason) {
     let conf = boosterConf();
@@ -393,33 +435,10 @@ async function revokeBooster(client, userId, reason) {
     let row = await boosterRow(client, userId);
     if (!row) return "nothing";
 
-    let player = await linkedPlayer(client, userId);
-    if (!player) player = row.player;
-
-    let current = await inGameRank(client, player);
-    let back = row.old_rank || defaultRank();
-    let outcome;
-
-    if (current === conf.rank) {
-        //Safety net first: an expired row makes MiniCore itself restore the rank at the next
-        //login, whatever happens to the RCON call below.
-        await query(client.mysqlingame, "UPDATE `temp_rank` SET `expire` = ? WHERE `player` = ? AND `new` = ?",
-            [nowSeconds() - 1, player, conf.rank]);
-
-        let result = await rconFirst(client, "setrank " + player + " " + back);
-        if (result) {
-            await query(client.mysqlingame, "DELETE FROM `temp_rank` WHERE `player` = ? AND `new` = ?", [player, conf.rank]);
-            await rconBroadcast(client, "setrank " + player + " " + back, result.port);
-            outcome = "restored";
-        } else {
-            outcome = "deferred";
-        }
-    } else {
-        //Someone else moved his rank in the meantime. Leave it alone, but drop our row so
-        //MiniCore does not undo their change at the next login.
-        await query(client.mysqlingame, "DELETE FROM `temp_rank` WHERE `player` = ? AND `new` = ?", [player, conf.rank]);
-        outcome = "superseded";
-    }
+    //The account we actually granted to, NOT whatever is linked right now: after an account
+    //change those differ, and acting on the new one would strip a rank we never posted.
+    let player = row.player;
+    let outcome = await releaseTempRank(client, player, row.old_rank || defaultRank());
 
     await query(client.mysqldiscord, "DELETE FROM `boosterRank` WHERE `user` = ?", [userId]);
     notified.delete(userId);
@@ -483,14 +502,14 @@ async function sweepRoles(client) {
             let player = await linkedPlayer(client, row.user);
             if (player) continue;
 
-            let roles = await grantedRoles(client, row.user);
-            let removed = await removeRoles(client, row.user, roles, "Compte de jeu delie");
-            await forgetRoles(client, row.user);
+            let granted = await grantedRoles(client, row.user);
+            let roles = await removeRoles(client, row.user, granted, "Compte de jeu delie");
+            await forgetRoles(client, row.user, roles.failed);
             await quiet(query(client.mysqldiscord, "DELETE FROM `tempRank` WHERE `user` = ?", [row.user]),
                 "Nettoyage de tempRank pour " + row.user);
 
-            if (removed.length) {
-                log(client, "<@" + row.user + "> n'est plus lie a un compte de jeu, " + removed.length + " role(s) de grade retire(s)");
+            if (roles.removed.length) {
+                log(client, "<@" + row.user + "> n'est plus lie a un compte de jeu, " + roles.removed.length + " role(s) de grade retire(s)");
             }
         } catch (err) {
             console.error("Reconciliation des roles de " + row.user + " : " + err);
@@ -506,8 +525,19 @@ async function sweepBoosters(client, members) {
         for (const row of rows) {
             try {
                 let member = members.get(row.user);
-                if (member && member.premiumSince) continue;
-                await revokeBooster(client, row.user, member ? "Fin du boost" : "Membre parti du serveur");
+                if (!member) {
+                    await revokeBooster(client, row.user, "Membre parti du serveur");
+                    continue;
+                }
+                if (!member.premiumSince) {
+                    await revokeBooster(client, row.user, "Fin du boost");
+                    continue;
+                }
+                //Still boosting is not enough. The account may have unlinked in game, which
+                //the bot is never told about, and the sibling pass above has already taken
+                //his discord roles back for exactly that reason.
+                let player = await linkedPlayer(client, row.user);
+                if (!player) await revokeBooster(client, row.user, "Compte de jeu delie");
             } catch (err) {
                 console.error("Retrait du grade booster de " + row.user + " : " + err);
             }

--- a/tasks.js
+++ b/tasks.js
@@ -2,6 +2,7 @@ const {ActivityType} = require("discord-api-types/v10");
 const mcutil = require('minecraft-server-util');
 const config = require('./config.json');
 const hidden = require('./hidden.json');
+const linkmanager = require('./linkmanager');
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 
 class run {
@@ -167,6 +168,8 @@ class run {
         this.changestatus();
         this.vote();
         this.checkCountBanned();
+        //Installs its own interval once, ready can fire again after a reconnection
+        linkmanager.start(client).catch(err => console.error("Démarrage du module de liaison : " + err));
         setInterval(() => {this.checkideas()}, 120 * 1000); //2 min
         setInterval(() => {client.xpapi.save()}, 600 * 1000); //10 min
         setInterval(() => {this.vote()}, 900 * 1000); //15 min


### PR DESCRIPTION
## Problem

An account that unlinked kept every rank role the link had granted. `+link remove` deleted the `discord_link` row and nothing else, and the only `roles.remove` for a rank role is driven by the temporary rank deadline, never by the unlink. Two further unlink paths exist that the bot is never told about: `/link remove` in game and the staff `datam` command.

Boosting the discord gave nothing in game. A search for `premiumSince`, `boost` or `nitro` returned zero matches, and `guildMemberUpdate.js` short circuited every transition except the rules acceptance.

The `Boosteur` rank already exists in `ranks.yml`, inheriting `Interplanetaire`. Nothing needed to be added on the PHP side.

## Changes

One commit per subject.

**Take the roles back on unlink.** `+link remove` removes the five `config.ranks` roles, the mirrored `tempRank` deadline and the in-game `Boosteur` rank. The member is resolved on `config.serverId`, not through `message.member`: the channel restriction only applies to the main guild, so the command is usable from the staff server where that would be the wrong member.

**Grant `Boosteur` while boosting.** A sliding 7 day temporary rank over RCON, refreshed hourly while the boost lasts and taken back as soon as it stops. New `linkmanager.js` holds the grant register, the booster rank, and an hourly reconciliation pass that catches the boosts, unboosts and unlinks the gateway cannot see.

**Never downgrade.** A player already holding a rank above `Boosteur`, or a temporary rank bought in the shop, keeps it and is told why in DM. `temp_rank.player` is `PRIMARY KEY UNIQUE` and `TempRank::addRank` destroys the existing row while keeping its `old`, so granting a boost over a shop purchase would have destroyed the purchase with no trace and no refund.

**Renewal is an absolute write.** `addRank` ADDS the remaining time when replayed with the same rank, so an hourly `temprank` would have grown the deadline without bound. The renewal is a direct `UPDATE temp_rank SET expire`.

**Only take back what the bot posted.** The pass reads a register of the roles the bot granted itself, so a rank offered by hand is never stripped, and a removal Discord refuses keeps its row for the next pass. The revoke path reads the account the bot actually granted to, not whatever is linked at that moment, so an account change cannot make it strip a rank it never posted.

**`refreshrank` fixes on the same path.** `roles.add(undefined)` crashed the process for every player whose in-game rank has no discord role, the nominal path of every new player linking. `rank` is now backticked in the `tempRank` insert: reserved from MySQL 8.0.2, and that insert carried no callback, so on MySQL 8 it failed silently and the whole role expiry was dead. A null `perms` no longer throws, duplicate deadline rows are gone, an Omega Perso holder gets his `Omega` role too, and a deadline row survives a failed removal.

## Cost

The pass asked the game database "is this member still linked" once per row in the register. `discord_link` has `player` for primary key and no index on `discord`, so each is a full table scan, and the pass grew with the players who ever held a paid rank.

Measured on a fake connection counting round trips, 3000 paid ranks and 40 boosters, one pass:

| | queries | link lookups | rows scanned |
|---|---|---|---|
| before | 3217 | 3080 | 9 347 800 |
| after | 103 | 6 | 18 210 |

Flat now: 103 at 200 paid ranks and 103 at 3000. Both destructive branches still confirm live before acting, and losing the snapshot degrades to the old reads instead of cancelling the pass.

## Configuration

`config.json` gains a `booster` block, shipped enabled. It is not excluded from the deploy rsync, so it lands on the server and overwrites any edit made there by hand. `rankRoleGrant` and `boosterRank` create themselves at startup. No npm dependency added.

## Testing

A harness fakes mysql2 and RCON, reproducing MiniCore's real semantics: one temporary rank per player, `temprank` adding the remaining time on a same rank replay, a different rank destroying the row while keeping its `old`, and expiry evaluated only on `PlayerJoinEvent`. 132 checks pass. Every guard was then broken on purpose to prove a check catches it: 23 mutants, 23 killed, sources restored and green afterwards.

**Not verified against the real server.** Nothing has run against the production database, a real RCON socket or a real guild. The two assumptions that would fail loudest: that `Boosteur` exists in `/root/configs/ranks.yml`, the copy the server actually reads rather than the one in the repo, and that the five `rconPorts` are reachable. Both fail closed and post to the staff log rather than writing anything.

Worth checking on the box before merging: the restart count in `pm2 describe histbot`, since `roles.add(undefined)` reached the global `uncaughtException` handler, which calls `process.exit()`.

## Left alone

`sweepMinutes` stays at 60. `guild.members.fetch()` downloads every member each pass, so 240 would cut most of that traffic at the cost of a missed transition waiting up to 4 hours instead of 1. That is a product call and the number depends on the guild size.

`Interplanetaire` stays in `eligibleRanks` even though `Boosteur` grants exactly its permission set, so the swap buys the nametag and nothing else while parking a permanent rank in `temp_rank.old`. Removing it is a one word config change.

